### PR TITLE
update ete version to 2.3.10

### DIFF
--- a/ete2/meta.yaml
+++ b/ete2/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: ete2
-  version: '2.2.1072'
+  version: '2.3.10'
 
 source:
-  fn: ete2-2.2.1072.tar.gz
-  url: https://pypi.python.org/packages/source/e/ete2/ete2-2.2.1072.tar.gz
-  md5: 2864ed149ac22afbc533199c9f8cb133
+  fn: ete2-2.3.10.tar.gz
+  url: https://pypi.python.org/packages/source/e/ete2/ete2-2.3.10.tar.gz
+  md5: 87bf020c25c293e8e4e1b1e02a3dc2b1
 
 build:
   number: 2


### PR DESCRIPTION
There is now an official anaconda repository for the etetoolkit (ete2 and ete3), https://anaconda.org/etetoolkit, but I have also updated ete2 to its latest version in bcbio. 
